### PR TITLE
Fix bug when page does not contain a TOC

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -247,6 +247,12 @@ class syntax_plugin_condition extends DokuWiki_Syntax_Plugin {
 			$bug = false;
 			$this->_loadtester();
 			$ok = $this->_processblocks($blocks, $bug);
+			
+			// Check if a TOC exists *before* accessing it
+			if ( !is_array($renderer->meta['description']['tableofcontents']) ) {
+				$renderer->meta['description']['tableofcontents'] = array();
+			}
+			
 			// Render content if all went well
 			$metatoc = $renderer->meta['description']['tableofcontents'];
 			if(!$bug) {
@@ -255,10 +261,6 @@ class syntax_plugin_condition extends DokuWiki_Syntax_Plugin {
 			  	if ( in_array($instruction[0], array('document_start', 'document_end') ) ) continue;
 			    call_user_func_array(array(&$renderer, $instruction[0]), $instruction[1]);
 			  }
-			}
-			
-			if ( !is_array($renderer->meta['description']['tableofcontents']) ) {
-				$renderer->meta['description']['tableofcontents'] = array();
 			}
 
 			$renderer->meta['description']['tableofcontents'] = array_merge($metatoc, $renderer->meta['description']['tableofcontents']); 


### PR DESCRIPTION
If this plugin is used in a page without a TOC (e.g., the sidebar), it produces the following error and does not show any content:

PHP Warning:  array_merge(): Argument #1 is not an array in /var/www/dokuwiki/lib/plugins/condition/syntax.php on line 264

The change fixes this by moving the check to the right place.
